### PR TITLE
Fix Azure DevOps test connection endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -1157,7 +1157,7 @@ try {
   app.set('io', io);
 
   app.use('/api/ado/webhooks', adoWebhooksRouter);
-  app.use('/api/ado/project-config', adoProjectConfigRouter);
+  app.use('/api/ado', adoProjectConfigRouter);
   app.use('/api/ado/dashboard', adoDashboardRouter);
 } catch (error) {
   console.warn('⚠️ Azure DevOps routes not available:', error.message);

--- a/server.ts
+++ b/server.ts
@@ -404,7 +404,21 @@ function setupRoutes(): void {
       const mvpDashboardRoutes = require('./routes/mvp-dashboard');
       app.use('/mvp', mvpDashboardRoutes);
     } catch (e) { console.warn('MVP dashboard routes not available'); }
-    
+
+    // Azure DevOps routes
+    try {
+      const adoWebhooksRouter = require('./routes/ado-webhooks');
+      const adoProjectConfigRouter = require('./routes/ado-project-config');
+      const adoDashboardRouter = require('./routes/ado-dashboard');
+
+      // Store io instance for webhook access
+      app.set('io', io);
+
+      app.use('/api/ado/webhooks', adoWebhooksRouter);
+      app.use('/api/ado', adoProjectConfigRouter);
+      app.use('/api/ado/dashboard', adoDashboardRouter);
+    } catch (e) { console.warn('Azure DevOps routes not available'); }
+
     // Week 9+ orchestration routes
     try {
       const testWebhookRoutes = require('./routes/test-webhooks');


### PR DESCRIPTION
## Summary
- ensure Azure DevOps project configuration routes are mounted at `/api/ado`
- mount Azure DevOps routes in TypeScript server

## Testing
- `npm test` *(fails: Chromium distribution 'msedge' is not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891253e7ce483208c9a4a536e4b5cfa